### PR TITLE
check the password (!) before enabling sudo mode + small code cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ cp local_settings.py.template local_settings.py
 # Change “company” and “Company” (e.g. to “futurice” and “Futurice”) throughout the file
 # set USE_TLS=False if some LDAP connections don't work
 # Change EMAIL_DOMAIN and EMAIL_HOST (e.g. replace example.com with futurice.com)
+# Change IT_TEAM to an existing group you're part of to get SUDO permission
 ```
 
 Run using Vagrant

--- a/fum/common/ldap_test_suite.py
+++ b/fum/common/ldap_test_suite.py
@@ -101,7 +101,7 @@ class LdapFunctionality(object):
         self.client = Client()
         self.client.login(username=self.USERNAME, password=self.PASSWORD)
 
-        self.assertTrue(test_user_ldap(self.USERNAME, self.PASSWORD, connection=self.ldap.connection))
+        self.assertTrue(test_user_ldap(self.USERNAME, self.PASSWORD))
 
     def tearDown(self):
         self.client.logout()

--- a/fum/ldap_helpers.py
+++ b/fum/ldap_helpers.py
@@ -44,19 +44,18 @@ def fetch(self, dn, filters='', attrs=[], scope=ldap.SCOPE_BASE, connection=None
 
     return result
 
-def test_user_ldap(username, password, connection=None):
+def test_user_ldap(username, password):
     '''
     Test that user has access to ldap with given credentials.
     Returns true or false
     '''
     from fum.models import Users
-    if len(username)>0 and len(password)>0:
+    if username and password:
         user = Users.objects.get(username=username)
         try:
-            if connection is None:
-                user.ldap._connection = LDAPBridge(parent=user, BIND_DN=user.get_dn(), BIND_PASSWORD=password).connection
-            else:
-                user.ldap._connection = connection
+            # throws an exception if the password is incorrect
+            LDAPBridge(parent=user, BIND_DN=user.get_dn(),
+                    BIND_PASSWORD=password).connection
             return True
         except Exception, e:
             print "ERROR#helpers: %s, %s"%(username,e)


### PR DESCRIPTION
Running the tests with `--settings=fum.settings.test_live` because of this.

Test Plan: run all tests, type good/bad password for SUDO, change my own password without sudo, change other users' password with sudo (both by typing and to a random one).