### PR TITLE
Remove unnecessary options from pip install

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ INSTALL
 
 ```
 apt-get install build-essential python-setuptools python-dev libldap2-dev libsasl2-dev libssl-dev libxslt1-dev
-pip install --allow-external PIL --allow-unverified PIL -r requirements.txt
+pip install -r requirements.txt
 npm install
 
 cp local_settings.py.template local_settings.py

--- a/fabfile.py
+++ b/fabfile.py
@@ -152,7 +152,6 @@ def prepare_python_packages():
     missing_requirements.flush()
     local('pip install'
          ' --no-use-wheel'
-          ' --allow-external PIL --allow-unverified PIL'
           ' -d {env.local_python_packages_dir}'
           ' --exists-action=i'
           ' -r {missing_requirements_file}'


### PR DESCRIPTION
No need for the extra options after fixes related to #25 