### PR TITLE
run with Vagrant

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ media/
 dist/
 /static/
 /logs/
+
+/.vagrant/

--- a/README.md
+++ b/README.md
@@ -6,6 +6,29 @@ BACKGROUND
 ==========
 **FUM** was created as an internal support system at [Futurice](http://www.futurice.com). It was open sourced as a part of the [Summer of Love](http://blog.futurice.com/summer-of-love-of-open-source) program.
 
+SETUP
+=====
+```bash
+cp local_settings.py.template local_settings.py
+# set the SECRET_KEY to a random string
+# Fill in the LDAP_CONNECTION fields
+# Change “company” and “Company” (e.g. to “futurice” and “Futurice”) throughout the file
+# set USE_TLS=False if some LDAP connections don't work
+# Change EMAIL_DOMAIN and EMAIL_HOST (e.g. replace example.com with futurice.com)
+```
+
+Run using Vagrant
+=================
+Enter your username in `vagrant/REMOTE_USER`, e.g.:
+```bash
+echo username >vagrant/REMOTE_USER
+```
+
+```bash
+vagrant up
+```
+[localhost:8000](http://localhost:8000)
+
 INSTALL
 =======
 
@@ -13,13 +36,6 @@ INSTALL
 apt-get install build-essential python-setuptools python-dev libldap2-dev libsasl2-dev libssl-dev libxslt1-dev
 pip install -r requirements.txt
 npm install
-
-cp local_settings.py.template local_settings.py
-# set the SECRET_KEY to a random string
-# Fill in the LDAP_CONNECTION fields
-# Change “company” and “Company” (e.g. to “futurice” and “Futurice”) throughout the file
-# set USE_TLS=False if LDAP connections don't work
-# Change EMAIL_DOMAIN and EMAIL_HOST (e.g. replace example.com with futurice.com)
 
 mkdir -p media/portraits/full media/portraits/thumb
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,21 @@
+# Vagrantfile API/syntax version. Don't touch unless you know what you're doing!
+VAGRANTFILE_API_VERSION = "2"
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+  # Every Vagrant virtual environment requires a box to build off of.
+  config.vm.box = "ubuntu/trusty64"
+
+  config.vm.provider "virtualbox" do |v|
+    v.memory = 1024
+  end
+
+  config.vm.network "forwarded_port", guest: 8000, host: 8000
+
+  config.vm.provision "shell", path: "vagrant/provision-root.sh"
+  config.vm.provision "shell", privileged: false,
+    path: "vagrant/provision-user.sh"
+
+  config.vm.provision "shell", run: "always", path: "vagrant/always-root.sh"
+  config.vm.provision "shell", run: "always", privileged: false,
+    path: "vagrant/always-user.sh"
+end

--- a/vagrant/.gitignore
+++ b/vagrant/.gitignore
@@ -1,0 +1,1 @@
+/REMOTE_USER

--- a/vagrant/always-root.sh
+++ b/vagrant/always-root.sh
@@ -1,0 +1,9 @@
+#! /usr/bin/env bash
+
+set -u  # exit if using uninitialised variable
+set -e  # exit if some command in this script fails
+trap "echo $0 failed because a command in the script failed" ERR
+
+ROOT_DIR="/vagrant"
+
+pip install -r "$ROOT_DIR"/requirements.txt

--- a/vagrant/always-user.sh
+++ b/vagrant/always-user.sh
@@ -1,0 +1,23 @@
+#! /usr/bin/env bash
+
+set -u  # exit if using uninitialised variable
+set -e  # exit if some command in this script fails
+trap "echo $0 failed because a command in the script failed" ERR
+
+
+cd /vagrant
+
+npm install
+
+mkdir -p media/portraits/full media/portraits/thumb
+python ./manage.py test --settings=fum.settings.test
+
+./manage.py migrate --noinput
+./manage.py collectstatic --noinput
+
+
+# TODO: improve this
+# Run 2 processes in the background
+PATH=./node_modules/.bin:$PATH ./watcher.py &
+REMOTE_USER=`cat vagrant/REMOTE_USER` \
+	./manage.py runserver --nostatic 0.0.0.0:8000 &

--- a/vagrant/apt-get.sh
+++ b/vagrant/apt-get.sh
@@ -1,0 +1,20 @@
+#! /usr/bin/env bash
+
+set -u  # exit if using uninitialised variable
+set -e  # exit if some command in this script fails
+trap "echo $0 failed because a command in the script failed" ERR
+
+apt-get update
+apt-get install -y \
+	build-essential htop \
+	python-dev python-pip python-virtualenv \
+	libxml2-dev libxslt1-dev \
+	libcurl4-openssl-dev libssl-dev zlib1g-dev libpcre3-dev \
+	libldap2-dev libsasl2-dev \
+	libjpeg-dev \
+	libfreetype6-dev \
+	postgresql libpq-dev \
+	npm \
+	memcached
+
+ln -s /usr/bin/nodejs /usr/bin/node

--- a/vagrant/postgresql.sh
+++ b/vagrant/postgresql.sh
@@ -1,0 +1,13 @@
+#! /usr/bin/env bash
+
+set -u  # exit if using uninitialised variable
+set -e  # exit if some command in this script fails
+trap "echo $0 failed because a command in the script failed" ERR
+
+sudo -u postgres createuser vagrant
+sudo -u postgres psql -c 'alter user vagrant with createdb' postgres
+
+# fragile: disable password
+sed -e 's|^host    all             all             127.0.0.1/32            md5$|host    all             all             127.0.0.1/32            trust|' -i /etc/postgresql/9.*/main/pg_hba.conf
+
+service postgresql restart

--- a/vagrant/provision-root.sh
+++ b/vagrant/provision-root.sh
@@ -1,0 +1,15 @@
+#! /usr/bin/env bash
+
+set -u  # exit if using uninitialised variable
+set -e  # exit if some command in this script fails
+trap "echo $0 failed because a command in the script failed" ERR
+
+ROOT_DIR=/vagrant
+VAGRANT_DIR="$ROOT_DIR"/vagrant
+
+"$VAGRANT_DIR"/apt-get.sh
+"$VAGRANT_DIR"/postgresql.sh
+
+# To run ‘datamigrate’ at provision-*.sh time, we need these commands
+# which also run at always-*.sh time.
+pip install -r "$ROOT_DIR"/requirements.txt

--- a/vagrant/provision-user.sh
+++ b/vagrant/provision-user.sh
@@ -1,0 +1,17 @@
+#! /usr/bin/env bash
+
+set -u  # exit if using uninitialised variable
+set -e  # exit if some command in this script fails
+trap "echo $0 failed because a command in the script failed" ERR
+
+
+createdb fum
+
+# To run ‘datamigrate’ at provision-*.sh time, we need these commands
+# which also run at always-*.sh time.
+cd /vagrant
+mkdir -p media/portraits/full media/portraits/thumb
+python manage.py test --settings=fum.settings.test
+./manage.py migrate --noinput
+
+./manage.py datamigrate


### PR DESCRIPTION
Run all tests on ‘vagrant up’.
Runs ‘datamigrate’ when creating the vm for the first time.
Runs watcher.py and the webserver as background processes from the
startup vagrant script: this can be improved.