### PR TITLE
RFC: set fields to the empty value (delete from LDAP)

### DIFF
--- a/fum/api/tests.py
+++ b/fum/api/tests.py
@@ -567,7 +567,7 @@ class LdapTestCase(LdapSuite):
         self.assertEquals(modlist.modifyModlist({'key': 'old-value'}, {'key': ''}), [(1, 'key', None)])
 
         mlist = self.ldap.get_modify_modlist(modified_values)
-        self.assertEquals(mlist, [(2, 'key', '')])
+        self.assertEquals(mlist, [(2, 'key', None)])
 
         modified_values = {'key': 'foo'}
         self.assertEquals(modlist.modifyModlist({'key': ''}, {'key': 'foo'}), [(0, 'key', 'foo')])

--- a/fum/api/tests.py
+++ b/fum/api/tests.py
@@ -574,6 +574,18 @@ class LdapTestCase(LdapSuite):
         mlist = self.ldap.get_modify_modlist(modified_values)
         self.assertEquals(mlist, [(2, 'key', 'foo')])
 
+        self.user.title = 'Title'
+        self.user.save()
+        self.assertEquals(self.user.lval().get('title'), ['Title'])
+
+        self.user.title = ''
+        self.user.save()
+        self.assertEquals(self.user.lval().get('title'), None)
+
+        self.user.title = 'NewTitle'
+        self.user.save()
+        self.assertEquals(self.user.lval().get('title'), ['NewTitle'])
+
 class ApiTestCase(LdapTransactionSuite):
 
     def setUp(self):

--- a/fum/ldap_helpers.py
+++ b/fum/ldap_helpers.py
@@ -145,15 +145,15 @@ class LDAPBridge(object):
         return self._get_connection()
     connection = property(_get_bound_connection)
 
-    def get_modify_modlist(self, values, force_update=False, keep_empty=True):
+    def get_modify_modlist(self, values, force_update=False):
         """ Current values are always empty, requiring extra hand-holding for empty values.
         @TODO pass existing values """
         current_values = {}
         mlist = modlist.modifyModlist(current_values, values)
         mlist_keys = [k[1] for k in mlist]
         for k, m in enumerate(values.keys()):
-            if keep_empty and m not in mlist_keys:
-                mlist.append((ldap.MOD_REPLACE, m, ''))
+            if m not in mlist_keys:
+                mlist.append((ldap.MOD_DELETE, m, None))
         for k, m in enumerate(mlist):
             mlist[k] = (ldap.MOD_REPLACE, mlist[k][1], mlist[k][2])
         return mlist

--- a/fum/ldap_helpers.py
+++ b/fum/ldap_helpers.py
@@ -146,14 +146,14 @@ class LDAPBridge(object):
     connection = property(_get_bound_connection)
 
     def get_modify_modlist(self, values, force_update=False):
-        """ Current values are always empty, requiring extra hand-holding for empty values.
-        @TODO pass existing values """
+        """ Empty values are not seen as changes due comparing to {};
+        when (empty key values) found, manually added as changed"""
         current_values = {}
         mlist = modlist.modifyModlist(current_values, values)
         mlist_keys = [k[1] for k in mlist]
         for k, m in enumerate(values.keys()):
             if m not in mlist_keys:
-                mlist.append((ldap.MOD_DELETE, m, None))
+                mlist.append((ldap.MOD_REPLACE, m, None))
         for k, m in enumerate(mlist):
             mlist[k] = (ldap.MOD_REPLACE, mlist[k][1], mlist[k][2])
         return mlist


### PR DESCRIPTION
Setting fields (e.g. Phone 2, Title) to the empty string throws an
exception and doesn't do anything.
This change sets the FUM field to the empty string and deletes it from
LDAP.