### PR TITLE
tests: add ‘fum’ to the ‘manage.py test’ command for vagrant and travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,4 +30,4 @@ install:
     -e "s/Company/Futurice/g"
     -e 's/example\.com/futurice.com/g'
 
-script: python manage.py test --settings=fum.settings.test --noinput
+script: python manage.py test --settings=fum.settings.test --noinput fum

--- a/vagrant/always-user.sh
+++ b/vagrant/always-user.sh
@@ -10,7 +10,7 @@ cd /vagrant
 npm install
 
 mkdir -p media/portraits/full media/portraits/thumb media/portraits/badge
-python ./manage.py test --settings=fum.settings.test
+python manage.py test --settings=fum.settings.test --noinput fum
 
 ./manage.py migrate --noinput
 ./manage.py collectstatic --noinput

--- a/vagrant/provision-user.sh
+++ b/vagrant/provision-user.sh
@@ -11,7 +11,7 @@ createdb fum
 # which also run at always-*.sh time.
 cd /vagrant
 mkdir -p media/portraits/full media/portraits/thumb media/portraits/badge
-python manage.py test --settings=fum.settings.test
+python manage.py test --settings=fum.settings.test --noinput fum
 ./manage.py migrate --noinput
 
 ./manage.py datamigrate


### PR DESCRIPTION
Otherwise some test fails most of the time when run via ‘vagrant up’.
Doing ‘vagrant ssh’ and typing the ‘manage.py test’ command works, so I
don't know why the same command fails when run by ‘vagrant up’.
Travis-CI also now fails without ‘fum’ but passes with it.