### PR TITLE
prevent the photo modal dialogs from overflowing the page

### DIFF
--- a/fum/common/static/css/main.less
+++ b/fum/common/static/css/main.less
@@ -130,11 +130,10 @@ a.status-suspended {
 }
 
 #portrait-modal {
-  width: 40%;
+  min-width: 40%;
   margin-left: 0px;
   left: 30%;
   height: 70%;
-  min-height: 600px;
 }
 
 #portrait-preview {
@@ -160,13 +159,38 @@ a.status-suspended {
   float: left;
 }
 
-/* ensure the badge cropping dialogs are tall enough, else a tall (portrait)
-   full image or badge crop scrolls inside a smaller dialog box. */
+div#badge-modal-view {
+  height: 70%;
+}
 div#badge-modal-view > div.modal-body {
-  max-height: none;
+  height: 80%;
+  max-height: 80%;
+}
+img#badge-view {
+  height: auto;
+  width: auto;
+  max-height: 100%;
+  max-width: 100%;
+  display: block;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+div#badge-modal-edit {
+  height: 70%;
 }
 div#badge-modal-edit > div.modal-body {
-  max-height: none;
+  height: 80%;
+  max-height: 80%;
+}
+img#badge-edit {
+  height: auto;
+  width: auto;
+  max-height: 100%;
+  max-width: 100%;
+  display: block;
+  margin-left: auto;
+  margin-right: auto;
 }
 
 /* Portrait stuff ends


### PR DESCRIPTION
The photo upload dialog was fine, but change `width` to `min-width` so we
don't squash the footer & buttons. It doesn't get too wide because of an
inherited rule `width: 560px` from bootstrap.

Copy the styling of the photo upload dialogs to the badge cropping:
modal container 70% height
modal body 80% of that
nested `<img>` 100% of its available space.

Tested with small & large browser window. Large photos.