### PR TITLE
make test pass when run by vagrant provisioner by adding an env var

### DIFF
--- a/vagrant/always-user.sh
+++ b/vagrant/always-user.sh
@@ -10,7 +10,19 @@ cd /vagrant
 npm install
 
 mkdir -p media/portraits/full media/portraits/thumb media/portraits/badge
-python manage.py test --settings=fum.settings.test --noinput fum
+
+# The test fum.api.tests.ApiTestCase.test_user fails if run via the vagrant
+# shell provisioner or via ‘vagrant ssh -c 'python manage.py test …'’.
+# self.ldap_val('mail', user) returns [] instead of raising KeyError.
+# The test succeeds if run via:
+# ― ‘vagrant ssh’ followed by ‘python manage.py test …’
+# ― ‘python manage.py test …’ on a dev machine
+# ― .travis.yml
+# Adding an environment variable (with any name and value) solves the problem.
+#
+# TODO: understand the cause of this.
+DUMMY_VAR=dummy_val \
+	python manage.py test --settings=fum.settings.test --noinput fum
 
 ./manage.py migrate --noinput
 ./manage.py collectstatic --noinput

--- a/vagrant/provision-user.sh
+++ b/vagrant/provision-user.sh
@@ -11,7 +11,11 @@ createdb fum
 # which also run at always-*.sh time.
 cd /vagrant
 mkdir -p media/portraits/full media/portraits/thumb media/portraits/badge
-python manage.py test --settings=fum.settings.test --noinput fum
+
+# see the comment in always-user.sh for the environment variable
+DUMMY_VAR=dummy_val \
+	python manage.py test --settings=fum.settings.test --noinput fum
+
 ./manage.py migrate --noinput
 
 ./manage.py datamigrate


### PR DESCRIPTION
The mysterious failure is just as mysteriously solved by adding any
environment variable.
TODO: understand the root cause of this and fix that or at least
document it and the workaround.