### PR TITLE
add github field to Users

### DIFF
--- a/fum/api/serializers.py
+++ b/fum/api/serializers.py
@@ -94,7 +94,7 @@ class UsersSerializer(GenericRelationModelManager):
 
     class Meta:
         model = Users
-        fields = ('id','first_name', 'last_name', 'username', 'title', 'phone1', 'phone2', 'email', 'skype',
+        fields = ('id','first_name', 'last_name', 'username', 'title', 'phone1', 'phone2', 'email', 'github', 'skype',
                 'physical_office', 'google_status', 'email_aliases', 'portrait_full_url', 'portrait_thumb_url', 'portrait_badge_url',
                 'home_directory', 'suspended_date', 'supervisor', 'hr_number','password_expiration_date',
                 'active_in_planmill','password_changed_date','status',)

--- a/fum/migrations/0004_users_github.py
+++ b/fum/migrations/0004_users_github.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('fum', '0003_users_portrait_badge_name'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='users',
+            name='github',
+            field=models.CharField(max_length=100, blank=True),
+            preserve_default=True,
+        ),
+    ]

--- a/fum/models.py
+++ b/fum/models.py
@@ -399,6 +399,7 @@ class Users(LDAPGroupModel):
     phone1 = models.CharField(max_length=100, null=True, blank=True)
     phone2 = models.CharField(max_length=100, null=True, blank=True)
     skype = models.CharField(max_length=100, null=True, blank=True)
+    github = models.CharField(max_length=100, null=False, blank=True)
     physical_office = models.CharField(max_length=100, null=True, blank=True)
     google_status = models.CharField(max_length=255, choices=GOOGLE_STATUS_CHOICES, default=UNDEFINED)
     picture_uploaded_date = models.DateTimeField(null=True, blank=True, editable=False)
@@ -588,7 +589,9 @@ class Users(LDAPGroupModel):
         return (u'%s %s'%(self.first_name or '', self.last_name or '')).strip()
 
     def search_data(self):
-        return u'%s %s %s %s %s %s'%(self.username, self.first_name, self.last_name, self.title, self.phone1, self.phone2,)
+        return u'%s %s %s %s %s %s %s'%(self.username,
+                self.first_name, self.last_name, self.title,
+                self.phone1, self.phone2, self.github)
 
     def is_in_teamit(self):
         try:

--- a/fum/users/templates/users/users_detail.html
+++ b/fum/users/templates/users/users_detail.html
@@ -282,6 +282,10 @@
 	</tr>
 
 	<tr>
+        {% include "common/xeditable.html" with field="github" full="GitHub" api=adetail %}
+	</tr>
+
+	<tr>
         {% include "common/xeditable.html" with field="skype" full="Skype" api=adetail %}
 	</tr>
 


### PR DESCRIPTION
Make the field non-null otherwise it will have 2 missing values ("" and
null) and users (e.g. of the API) might only code for one of these.

Later we could link to the GitHub profile (via the label on the profile or with a separate icon). I didn't find a trivial way to do this. Maybe modify `xeditable` to take an extra parameter.