### PR TITLE
removed postgresql from apt-get

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ install:
     libldap2-dev libsasl2-dev
     libjpeg-dev
     libfreetype6-dev
-    postgresql libpq-dev
+    libpq-dev
     npm
     memcached
   - npm install


### PR DESCRIPTION
Installing postgresql with apt-get was unnecessary (because it was already running) and caused an error (because it tried to install version 9.5 and we are using version 9.3)