### PR TITLE
Fix URL for adding servers

### DIFF
--- a/fum/servers/templates/servers/servers_list.html
+++ b/fum/servers/templates/servers/servers_list.html
@@ -4,7 +4,7 @@
 <h2>Servers</h2>
 
 <div>
-    <a href="{{ settings.VIMMA_URL }}" target="_blank" class="create_btn btn btn-success">+</a>
+    <a href="{% url obj_add %}" target="_blank" class="create_btn btn btn-success">+</a>
     <input type="text" class="search-query object-search">
 </div>
 


### PR DESCRIPTION
Fixes URL to use "url obj_add" instead of broken URL from base.py.